### PR TITLE
fix: make sure fetch requests don't get cached

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,16 @@
 {
   "name": "wherobots-sql-driver",
-  "version": "0.1.0-alpha.0",
+  "version": "0.1.0-alpha.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wherobots-sql-driver",
-      "version": "0.1.0-alpha.0",
+      "version": "0.1.0-alpha.2",
       "license": "Apache-2.0",
       "dependencies": {
         "apache-arrow": "^17.0.0",
+        "bufferutil": "^4.0.8",
         "cbor": "^9.0.2",
         "fetch-retry": "^6.0.0",
         "pino": "^9.3.2",
@@ -2642,6 +2643,19 @@
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
       "dev": true
+    },
+    "node_modules/bufferutil": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/bufferutil/-/bufferutil-4.0.8.tgz",
+      "integrity": "sha512-4T53u4PdgsXqKaIctwF8ifXlRTTmEPJ8iEPWFdGZvcf7sbwYo6FKFEX9eNNAnzFZ7EzJAQ3CJeOtCRA4rDp7Pw==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "node-gyp-build": "^4.3.0"
+      },
+      "engines": {
+        "node": ">=6.14.2"
+      }
     },
     "node_modules/cac": {
       "version": "6.7.14",
@@ -5954,6 +5968,17 @@
         "encoding": {
           "optional": true
         }
+      }
+    },
+    "node_modules/node-gyp-build": {
+      "version": "4.8.2",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.2.tgz",
+      "integrity": "sha512-IRUxE4BVsHWXkV/SFOut4qTlagw2aM8T5/vnTsmrHJvVoKueJHRc/JaFND7QDDc61kLYUJ6qlZM3sqTSyx2dTw==",
+      "license": "MIT",
+      "bin": {
+        "node-gyp-build": "bin.js",
+        "node-gyp-build-optional": "optional.js",
+        "node-gyp-build-test": "build-test.js"
       }
     },
     "node_modules/nofilter": {

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
   },
   "dependencies": {
     "apache-arrow": "^17.0.0",
+    "bufferutil": "^4.0.8",
     "cbor": "^9.0.2",
     "fetch-retry": "^6.0.0",
     "pino": "^9.3.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wherobots-sql-driver",
-  "version": "0.1.0-alpha.1",
+  "version": "0.1.0-alpha.2",
   "description": "TypeScript SDK for Wherobots DB",
   "license": "Apache-2.0",
   "main": "dist/src/index.js",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,8 +10,8 @@
     "paths": {
       "@/*": ["./src/*"]
     },
-    "outDir": "./dist",
+    "outDir": "./dist"
   },
   "include": ["**/*.ts", "**/*.mts"],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules", "./dist"]
 }


### PR DESCRIPTION
hard lesson learned attempting to dogfood the SDK, some fetch implementations *really* want to cache the requests we make to poll the status of the session, and if the do get cached the session will appear to stuck in a pending state forever.

specifically, the fetch implementation in server-side react will memoize all GET requests, regardless of the cache-control headers we send, and the only way opt out is to add an abort controller signal to the request. see: https://nextjs.org/docs/app/building-your-application/caching#opting-out

drive-by improvement:
- exclude "dist" folder from typescript compilation