### PR TITLE
feat(BUG-266): add API to abort an individual execution

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,9 +95,9 @@ parameter, passing in one of the `Runtime` enum values. For more
 information on runtime sizing and selection, please consult the
 [Wherobots product documentation](https://docs.wherobots.com).
 
-### Additional parameters
+### Additional parameters to `connect()`
 
-The `Connection.connect()` can take the following additional options:
+The `Connection.connect()` function can take the following additional options:
 
 - `resultsFormat`: one of the `ResultsFormat` enum values;
   Arrow encoding is the default and most efficient format for
@@ -119,3 +119,9 @@ The `Connection.connect()` can take the following additional options:
 
 - `region`: Currently, the only supported Wherobots compute region is `aws-us-west-2`,
   in AWS's Oregon (`us-west-2`) region.
+
+### Additional parameters to `execute()`
+
+The `Connection#execute` method can take an optional second argument, `options`:
+
+- `options.signal`: an `AbortSignal` which can be used to cancel the execution (optional)

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "fetch-retry": "^6.0.0",
         "pino": "^9.3.2",
         "pino-pretty": "^11.2.2",
+        "semver": "^7.6.3",
         "uuid": "^10.0.0",
         "ws": "^8.18.0",
         "zod": "^3.23.8"
@@ -25,6 +26,7 @@
         "@swc-node/register": "^1.10.9",
         "@tsconfig/node-lts": "^20.1.3",
         "@tsconfig/strictest": "^2.0.5",
+        "@types/semver": "^7.5.8",
         "@types/uuid": "^10.0.0",
         "@types/ws": "^8.5.12",
         "@typescript-eslint/eslint-plugin": "^7.18.0",
@@ -1869,6 +1871,13 @@
       "dependencies": {
         "undici-types": "~6.19.2"
       }
+    },
+    "node_modules/@types/semver": {
+      "version": "7.5.8",
+      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.8.tgz",
+      "integrity": "sha512-I8EUhyrgfLrcTkzV3TSsGyl1tSuPrEDzr0yd5m90UgNxQkyDXULk3b6MlQqTCpZpNtWe1K0hzclnZkTcLBe2UQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/uuid": {
       "version": "10.0.0",
@@ -6934,7 +6943,7 @@
       "version": "7.6.3",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
       "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
-      "dev": true,
+      "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
       },

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "@swc-node/register": "^1.10.9",
     "@tsconfig/node-lts": "^20.1.3",
     "@tsconfig/strictest": "^2.0.5",
+    "@types/semver": "^7.5.8",
     "@types/uuid": "^10.0.0",
     "@types/ws": "^8.5.12",
     "@typescript-eslint/eslint-plugin": "^7.18.0",
@@ -60,6 +61,7 @@
     "fetch-retry": "^6.0.0",
     "pino": "^9.3.2",
     "pino-pretty": "^11.2.2",
+    "semver": "^7.6.3",
     "uuid": "^10.0.0",
     "ws": "^8.18.0",
     "zod": "^3.23.8"

--- a/src/api-utils.ts
+++ b/src/api-utils.ts
@@ -92,3 +92,20 @@ export const decodeResults = <Schema extends TypeMap>(
       throw new Error(`Unsupported encoding: ${encoding}`);
   }
 };
+
+// we can use AbortSignal.any() once we don't support Node 18
+export const combineAbortSignals = (
+  ...signals: (AbortSignal | undefined)[]
+): AbortSignal => {
+  const controller = new AbortController();
+  signals.forEach((signal) => {
+    if (signal) {
+      if (signal.aborted) {
+        controller.abort(signal.reason);
+        return;
+      }
+      signal.addEventListener("abort", () => controller.abort(signal.reason));
+    }
+  });
+  return controller.signal;
+};

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -55,3 +55,5 @@ export enum SessionStatus {
   DESTROY_FAILED = "DESTROY_FAILED",
   DESTROYED = "DESTROYED",
 }
+
+export const MIN_PROTOCOL_VERSION_FOR_CANCEL = "1.1.0";

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -93,6 +93,13 @@ export const RetrieveResultsEventSchema = z.object({
 
 export type RetrieveResultsEvent = z.infer<typeof RetrieveResultsEventSchema>;
 
+export const CancelExecutionEventSchema = z.object({
+  kind: z.literal("cancel"),
+  execution_id: ExecutionIdSchema,
+});
+
+export type CancelExecutionEvent = z.infer<typeof CancelExecutionEventSchema>;
+
 export const EventWithExecutionIdSchema = z.object({
   execution_id: ExecutionIdSchema,
 });


### PR DESCRIPTION
caller can pass in an AbortSignal to the execute method, and if the signal is aborted, the SDK will stop sending / listening for messages for that execution.