### PR TITLE
fix(BUG-265, EWT-1394): add timout and retry logic when establishing …

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,6 @@
         "apache-arrow": "^17.0.0",
         "bufferutil": "^4.0.8",
         "cbor": "^9.0.2",
-        "fetch-retry": "^6.0.0",
         "pino": "^9.3.2",
         "pino-pretty": "^11.2.2",
         "semver": "^7.6.3",
@@ -4414,12 +4413,6 @@
       "dependencies": {
         "reusify": "^1.0.4"
       }
-    },
-    "node_modules/fetch-retry": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/fetch-retry/-/fetch-retry-6.0.0.tgz",
-      "integrity": "sha512-BUFj1aMubgib37I3v4q78fYo63Po7t4HUPTpQ6/QE6yK6cIQrP+W43FYToeTEyg5m2Y7eFUtijUuAv/PDlWuag==",
-      "license": "MIT"
     },
     "node_modules/file-entry-cache": {
       "version": "6.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wherobots-sql-driver",
-  "version": "0.1.0-alpha.2",
+  "version": "0.1.0-alpha.3",
   "description": "TypeScript SDK for Wherobots DB",
   "license": "Apache-2.0",
   "main": "dist/src/index.js",
@@ -58,7 +58,6 @@
     "apache-arrow": "^17.0.0",
     "bufferutil": "^4.0.8",
     "cbor": "^9.0.2",
-    "fetch-retry": "^6.0.0",
     "pino": "^9.3.2",
     "pino-pretty": "^11.2.2",
     "semver": "^7.6.3",

--- a/src/testing/mockSocketBehaviors.ts
+++ b/src/testing/mockSocketBehaviors.ts
@@ -152,6 +152,38 @@ export const simulateImmediatelyOpenSocket = (mockWebSocket: MockWebSocket) => {
   });
 };
 
+export const simulateSocketWithTransitentConnectionErrors = (
+  mockWebSocket: MockWebSocket,
+  options: { numInitialFailures: number },
+) => {
+  Array.from(Array(options.numInitialFailures)).forEach(() => {
+    mockWebSocket.mockImplementationOnce(() => {
+      const instance = mockWebSocketDefaultImplementation();
+      setTimeout(() =>
+        simulateWebSocketEvent(instance, {
+          type: "error",
+        } as WebSocket.Event),
+      );
+      return instance;
+    });
+  });
+  simulateImmediatelyOpenSocket(mockWebSocket);
+};
+
+export const simulateSocketWithConnectionTimeout = (
+  mockWebSocket: MockWebSocket,
+  options: { numTimeouts: number },
+) => {
+  Array.from(Array(options.numTimeouts)).forEach(() => {
+    // simulate a connection timeout by never sending an open event
+    mockWebSocket.mockImplementationOnce(() => {
+      const instance = mockWebSocketDefaultImplementation();
+      return instance;
+    });
+  });
+  simulateImmediatelyOpenSocket(mockWebSocket);
+};
+
 export const simulateSocketWithSingleExecution = (
   mockWebSocket: MockWebSocket,
 ) => {


### PR DESCRIPTION
…session

adds retry logic for http requests to establish the session, as well as for creating the websocket connection. also adds timeout handling to these operations

intentionally not attempting to add timeouts or retries for executing SQL statements, since the error messages don't give us enough information to decide if retrying would be a good idea, and there's no way to know a priori how long the execution is expected to take