### PR TITLE
fix: stop listening for timeout events after the connection is open

### DIFF
--- a/examples/connectionWithDefaults.ts
+++ b/examples/connectionWithDefaults.ts
@@ -15,6 +15,7 @@ import { Utf8 } from "apache-arrow";
   const conn = await Connection.connect({
     runtime: Runtime.SEDONA,
   });
+  await new Promise((resolve) => setTimeout(resolve, 15 * 1000));
   const results = await conn.execute<{ namespace: Utf8 }>(
     "SHOW SCHEMAS IN wherobots_open_data",
   );

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wherobots-sql-driver",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wherobots-sql-driver",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "Apache-2.0",
       "dependencies": {
         "apache-arrow": "^17.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wherobots-sql-driver",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "TypeScript SDK for Wherobots DB",
   "license": "Apache-2.0",
   "main": "dist/src/index.js",

--- a/src/connection.test.ts
+++ b/src/connection.test.ts
@@ -164,6 +164,7 @@ describe("Connection.connect, when establishing SQL session", () => {
     vi.runAllTimersAsync();
     await expect(connection).resolves.toBeInstanceOf(Connection);
     expect(fetchMock).toHaveBeenCalledTimes(SESSION_LIFECYCLE_RESPONSES.length);
+    expect(wasSocketClosed(MockWebSocket)).toEqual(false);
   });
 
   test("rejects if session create fails", async () => {

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -229,10 +229,11 @@ export class Connection {
     signal: AbortSignal,
   ): Promise<WebSocketApiSubset> {
     return new Promise((resolve, reject) => {
-      signal.addEventListener("abort", (e) => {
+      const onAbort = (e: Event) => {
         reject(new Error(e.type));
         cleanup(true);
-      });
+      };
+      signal.addEventListener("abort", onAbort);
       signal.throwIfAborted();
       const onSocketOpen = () => {
         cleanup();
@@ -243,6 +244,7 @@ export class Connection {
         reject(new Error(e.type));
       };
       const cleanup = (close?: boolean) => {
+        signal.removeEventListener("abort", onAbort);
         ws.removeEventListener("open", onSocketOpen);
         ws.removeEventListener("error", onSocketFail);
         ws.removeEventListener("close", onSocketFail);


### PR DESCRIPTION
there was a logic error causing the web socket connection logic to close the connection after the timeout event was emitted, even if the connection had successfully opened during that time