### PR TITLE
feat: activates logic to explicitly cancel an execution

### DIFF
--- a/examples/connectionWithCancellation.ts
+++ b/examples/connectionWithCancellation.ts
@@ -1,0 +1,29 @@
+/*
+ * run with:
+
+ *   `WHEROBOTS_API_KEY=<api key> node -r @swc-node/register examples/connectionWithCancellation.ts`
+ * 
+ * or for verbose logging:
+ * 
+ *   `NODE_DEBUG="wherobots-sql-driver" WHEROBOTS_API_KEY=<api key> node -r @swc-node/register examples/connectionWithCancellation.ts`
+ */
+
+import { Connection, Runtime } from "@/index";
+import { Utf8 } from "apache-arrow";
+
+(async () => {
+  const conn = await Connection.connect({
+    runtime: Runtime.SEDONA,
+  });
+  await new Promise((resolve) => setTimeout(resolve, 15 * 1000));
+  const abortController = new AbortController();
+  conn
+    .execute<{ namespace: Utf8 }>("SHOW SCHEMAS IN wherobots_open_data", {
+      signal: abortController.signal,
+    })
+    .catch((e) => {
+      console.log("caught error", e);
+    });
+  setTimeout(() => abortController.abort(), 100);
+  setTimeout(() => conn.close(), 5000);
+})();

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wherobots-sql-driver",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wherobots-sql-driver",
-      "version": "0.1.1",
+      "version": "0.2.0",
       "license": "Apache-2.0",
       "dependencies": {
         "apache-arrow": "^17.0.0",
@@ -15,7 +15,6 @@
         "pino": "^9.3.2",
         "pino-pretty": "^11.2.2",
         "read-pkg-up": "^7.0.0",
-        "semver": "^7.6.3",
         "uuid": "^10.0.0",
         "ws": "^8.18.0",
         "zod": "^3.23.8"
@@ -26,7 +25,6 @@
         "@swc-node/register": "^1.10.9",
         "@tsconfig/node-lts": "^20.1.3",
         "@tsconfig/strictest": "^2.0.5",
-        "@types/semver": "^7.5.8",
         "@types/uuid": "^10.0.0",
         "@types/ws": "^8.5.12",
         "@typescript-eslint/eslint-plugin": "^7.18.0",
@@ -1866,13 +1864,6 @@
       "version": "2.4.4",
       "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.4.tgz",
       "integrity": "sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==",
-      "license": "MIT"
-    },
-    "node_modules/@types/semver": {
-      "version": "7.5.8",
-      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.8.tgz",
-      "integrity": "sha512-I8EUhyrgfLrcTkzV3TSsGyl1tSuPrEDzr0yd5m90UgNxQkyDXULk3b6MlQqTCpZpNtWe1K0hzclnZkTcLBe2UQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/uuid": {
@@ -7059,6 +7050,7 @@
       "version": "7.6.3",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
       "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
+      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wherobots-sql-driver",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "TypeScript SDK for Wherobots DB",
   "license": "Apache-2.0",
   "main": "dist/src/index.js",
@@ -36,7 +36,6 @@
     "@swc-node/register": "^1.10.9",
     "@tsconfig/node-lts": "^20.1.3",
     "@tsconfig/strictest": "^2.0.5",
-    "@types/semver": "^7.5.8",
     "@types/uuid": "^10.0.0",
     "@types/ws": "^8.5.12",
     "@typescript-eslint/eslint-plugin": "^7.18.0",
@@ -62,7 +61,6 @@
     "pino": "^9.3.2",
     "pino-pretty": "^11.2.2",
     "read-pkg-up": "^7.0.0",
-    "semver": "^7.6.3",
     "uuid": "^10.0.0",
     "ws": "^8.18.0",
     "zod": "^3.23.8"

--- a/src/api-utils.ts
+++ b/src/api-utils.ts
@@ -175,7 +175,11 @@ export const combineAbortSignals = (
         controller.abort(signal.reason);
         return;
       }
-      signal.addEventListener("abort", () => controller.abort(signal.reason));
+      const onSignalAbort = () => controller.abort(signal.reason);
+      signal.addEventListener("abort", onSignalAbort);
+      controller.signal.addEventListener("abort", () =>
+        signal.removeEventListener("abort", onSignalAbort),
+      );
     }
   });
   return controller.signal;

--- a/src/connection.test.ts
+++ b/src/connection.test.ts
@@ -5,7 +5,7 @@ import { expect, test, describe, vi, beforeEach } from "vitest";
 // @ts-ignore
 import fetchMockBuilder from "vitest-fetch-mock";
 import { Connection } from "./connection";
-import { MIN_PROTOCOL_VERSION_FOR_CANCEL, Runtime } from "./constants";
+import { Runtime } from "./constants";
 import {
   SESSION_LIFECYCLE_RESPONSES,
   simulateImmediatelyReadySession,
@@ -85,13 +85,13 @@ const expectCorrectApiKey = () => {
   );
 };
 
-const createConnectionUnderTest = (protocolVersion?: string) =>
+const createConnectionUnderTest = () =>
   Connection.connect(
     {
       apiKey: testApiKey,
       runtime: Runtime.SEDONA,
     },
-    { ...testHarness, protocolVersion },
+    { ...testHarness },
   );
 
 beforeEach(() => {
@@ -111,6 +111,11 @@ describe("Connection.connect, when passed connection options", () => {
   });
 
   test("rejects if API key is missing", async () => {
+    if (process.env["WHEROBOTS_API_KEY"]) {
+      throw new Error(
+        "this test is invalid if WHEROBOTS_API_KEY environment variable is set",
+      );
+    }
     const connection = Connection.connect(
       {
         runtime: Runtime.SEDONA,
@@ -377,38 +382,10 @@ describe("Connection#execute, when executing a single SQL statement", async () =
     expectAllSocketListenersRemoved(MockWebSocket);
   });
 
-  test("stops listening/sending if execution is aborted", async () => {
+  test("sends cancellation if execution is aborted", async () => {
     simulateImmediatelyReadySession(fetchMock);
     const { resume } = simulateSocketWithSingleExecutionPaused(MockWebSocket);
     const connection = createConnectionUnderTest();
-    vi.runAllTimersAsync();
-    const abortController = new AbortController();
-    const result = (await connection).execute(
-      "SHOW SCHEMAS IN wherobots_open_data",
-      { signal: abortController.signal },
-    );
-    vi.runAllTimersAsync();
-    expect(getSentMessages(MockWebSocket)).toEqual([
-      expect.objectContaining({ kind: "execute_sql" }),
-    ]);
-    // aborting the execution before resuming the simulated socket should cause the promise to reject
-    // and no additional messages to be sent for this execution
-    abortController.abort();
-    resume();
-    vi.runAllTimersAsync();
-    await expect(result).rejects.toBeInstanceOf(Error);
-    expect(getSentMessages(MockWebSocket)).toEqual([
-      expect.objectContaining({ kind: "execute_sql" }),
-    ]);
-    expect(wasSocketClosed(MockWebSocket)).toEqual(false);
-  });
-
-  test("sends cancellation if execution is aborted for protocol version >= 1.1.0", async () => {
-    simulateImmediatelyReadySession(fetchMock);
-    const { resume } = simulateSocketWithSingleExecutionPaused(MockWebSocket);
-    const connection = createConnectionUnderTest(
-      MIN_PROTOCOL_VERSION_FOR_CANCEL,
-    );
     vi.runAllTimersAsync();
     const abortController = new AbortController();
     const result = (await connection).execute(

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -1,5 +1,4 @@
 import { decodeFirstSync } from "cbor";
-import semver from "semver";
 import * as uuid from "uuid";
 import WebSocket from "ws";
 import logger, { sessionContextLogger } from "./logger";
@@ -32,7 +31,6 @@ import {
 import z from "zod";
 import { Table, TypeMap } from "apache-arrow";
 import readPackageUp from "read-pkg-up";
-import { MIN_PROTOCOL_VERSION_FOR_CANCEL } from "./constants";
 
 // used to mock out the fetch and WebSocket APIs
 // in a unit testing environment
@@ -321,20 +319,19 @@ export class Connection {
   ): Promise<z.infer<T>> {
     return new Promise<z.infer<T>>((resolve, reject) => {
       const sendCancellation = () => {
-        if (semver.gte(this.protocolVersion, MIN_PROTOCOL_VERSION_FOR_CANCEL)) {
-          logger.child({ executionId }).debug("Sending cancel event");
-          const cancelEvent: CancelExecutionEvent = {
-            kind: "cancel",
-            execution_id: executionId,
-          };
-          this.ws?.send(JSON.stringify(cancelEvent));
-        }
+        logger.child({ executionId }).debug("Sending cancel event");
+        const cancelEvent: CancelExecutionEvent = {
+          kind: "cancel",
+          execution_id: executionId,
+        };
+        this.ws?.send(JSON.stringify(cancelEvent));
       };
-      abortSignal.addEventListener("abort", () => {
+      const handleSignalAborted = () => {
         sendCancellation();
         cleanup();
         reject(new Error("Execution aborted"));
-      });
+      };
+      abortSignal.addEventListener("abort", handleSignalAborted);
       if (abortSignal.aborted) {
         sendCancellation();
         reject(new Error("Execution aborted"));
@@ -349,6 +346,7 @@ export class Connection {
             if (isError) {
               logger.child(errorEvent).error("Error event received");
               cleanup();
+              abortSignal.removeEventListener("abort", handleSignalAborted);
               reject(new Error("Error event received"));
             }
           }
@@ -363,6 +361,7 @@ export class Connection {
           const data = schema.parse(toParse);
           if (data["execution_id"] === executionId) {
             cleanup();
+            abortSignal.removeEventListener("abort", handleSignalAborted);
             resolve(data);
           }
         } catch (err) {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -55,5 +55,3 @@ export enum SessionStatus {
   DESTROY_FAILED = "DESTROY_FAILED",
   DESTROYED = "DESTROYED",
 }
-
-export const MIN_PROTOCOL_VERSION_FOR_CANCEL = "1.1.0";


### PR DESCRIPTION
removes the protocol version check that was gating the logic to send a cancel message to the server when the execution is cancelled by the caller.

this exposed a leak in the listeners being added to abort controllers, which is fixed by proper listener teardown logic

bonus: adds better messaging to test that will incorrectly fail if the WHEROBOTS_API_KEY env var is set in the terminal session where tests are run