### PR TITLE
chore: switch away from city names for runtime specifiers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,22 @@
+# Changelog
+
+## 0.3.0
+
+### Changed
+
+- Updated naming conventions for Wherobots Runtimes, the following mappings can be used for migration:
+  - `Runtime.SEDONA` -> `Runtime.TINY`
+  - `Runtime.SAN_FRANCISCO` -> `Runtime.SMALL`
+  - `Runtime.NEW_YORK` -> `Runtime.MEDIUM`
+  - `Runtime.CAIRO` -> `Runtime.LARGE`
+  - `Runtime.DELHI` -> `Runtime.X_LARGE`
+  - `Runtime.TOKYO` -> `Runtime.XX_LARGE`
+  - `Runtime.ATLANTIS` -> `Runtime.XXXX_LARGE`
+  - `Runtime.NEW_YORK_HIMEM` -> `Runtime.MEDIUM_HIMEM`
+  - `Runtime.CAIRO_HIMEM` -> `Runtime.LARGE_HIMEM`
+  - `Runtime.DELHI_HIMEM` -> `Runtime.X_LARGE_HIMEM`
+  - `Runtime.TOKYO_HIMEM` -> `Runtime.XX_LARGE_HIMEM`
+  - `Runtime.ATLANTIS_HIMEM` -> `Runtime.XXXX_LARGE_HIMEM`
+  - `Runtime.SEDONA_GPU` -> `Runtime.TINY_A10_GPU`
+  - `Runtime.SAN_FRANCISCO_GPU` -> `Runtime.SMALL_A10_GPU`
+  - `Runtime.NEW_YORK_GPU` -> `Runtime.MEDIUM_A10_GPU`

--- a/README.md
+++ b/README.md
@@ -1,9 +1,13 @@
 # Wherobots TypeScript SDK
 
-TypeScript SDK for interacting with WherobotsDB. This package implements a Node.js
-client that programmatically connects to a WherobotsDB runtime and execute Spatial SQL queries.
+<!-- Note to authors: This content is duplicated from https://github.com/wherobots/documents/blob/source/docs/develop/spatial-sql-api.md#wherobots-sql-driver-typescript-sdk. When making updates here, please mirror them to the other location. -->
+
+This is the TypeScript SDK for interacting with WherobotsDB. This package implements a Node.js
+client that programmatically connects to a WherobotsDB runtime and executes Spatial SQL queries.
 
 ## Prerequisites
+
+The following resources are needed to run the Wherobots SQL Driver's TypeScript SDK:
 
 1. Node.js version 18 or higher
 1. TypeScript version 5.x (if using TypeScript)
@@ -12,16 +16,20 @@ client that programmatically connects to a WherobotsDB runtime and execute Spati
 
 ## Installation
 
-```
-$ npm install wherobots-sql-driver
+To complete the installation, run the following command:
+
+```bash
+npm install wherobots-sql-driver
 ```
 
 ## Usage
 
 ### Example: Executing SQL statement and printing results
 
-This example follows the typical pattern of an `async` function to establish the connection to WherobotsDB.
-After establishing this connection, you can call `async` methods to execute SQL queries through this connection.
+This example:
+
+- Establishes the connection to WherobotsDB with an `async` function
+- Calls `async` methods to execute SQL queries through this connection.
 
 ```ts
 import { Connection, Runtime } from "wherobots-sql-driver";
@@ -41,7 +49,7 @@ import { Connection, Runtime } from "wherobots-sql-driver";
 
 Running this example returns the results of the query as JSON:
 
-```
+```json
 [
   {
     "namespace": "overture"
@@ -67,7 +75,7 @@ Running this example returns the results of the query as JSON:
    in Wherobots Cloud and returns a `Connection` instance.
 1. Calling the connection's `execute()` methods runs the given SQL statement and
    asynchronously returns the result as an [Apache Arrow Table](https://arrow.apache.org/docs/js/classes/Arrow_dom.Table.html) instance.
-1. The Arrow Table instance can be converted to a primitive by calling `toArray()`, and then printed
+1. The Arrow Table instance is converted to a primitive by calling `toArray()`, and then printed
    to the console as formatted JSON with `JSON.stringify()`.
 1. Calling the connection's `close()` method tears down the SQL Session connection.
 
@@ -83,10 +91,8 @@ Running this example returns the results of the query as JSON:
 
 ### Runtime and region selection
 
-You can chose the Wherobots runtime you want to use using the `runtime`
-parameter, passing in one of the `Runtime` enum values. For more
-information on runtime sizing and selection, please consult the
-[Wherobots product documentation](https://docs.wherobots.com).
+Select your desired Wherobots runtime using the runtime parameter and specifying a runtime enum value.
+See the [Wherobots product documentation](https://docs.wherobots.com) for guidance on runtime sizing and selection.
 
 ### Additional parameters to `connect()`
 

--- a/examples/connectionWithCancellation.ts
+++ b/examples/connectionWithCancellation.ts
@@ -13,7 +13,7 @@ import { Utf8 } from "apache-arrow";
 
 (async () => {
   const conn = await Connection.connect({
-    runtime: Runtime.SEDONA,
+    runtime: Runtime.TINY,
   });
   await new Promise((resolve) => setTimeout(resolve, 15 * 1000));
   const abortController = new AbortController();

--- a/examples/connectionWithDefaults.ts
+++ b/examples/connectionWithDefaults.ts
@@ -13,7 +13,7 @@ import { Utf8 } from "apache-arrow";
 
 (async () => {
   const conn = await Connection.connect({
-    runtime: Runtime.SEDONA,
+    runtime: Runtime.TINY,
   });
   await new Promise((resolve) => setTimeout(resolve, 15 * 1000));
   const results = await conn.execute<{ namespace: Utf8 }>(

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wherobots-sql-driver",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wherobots-sql-driver",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "license": "Apache-2.0",
       "dependencies": {
         "apache-arrow": "^17.0.0",
@@ -3111,10 +3111,11 @@
       }
     },
     "node_modules/cross-spawn": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
         "shebang-command": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wherobots-sql-driver",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "TypeScript SDK for Wherobots DB",
   "license": "Apache-2.0",
   "main": "dist/src/index.js",

--- a/src/connection.test.ts
+++ b/src/connection.test.ts
@@ -89,7 +89,7 @@ const createConnectionUnderTest = () =>
   Connection.connect(
     {
       apiKey: testApiKey,
-      runtime: Runtime.SEDONA,
+      runtime: Runtime.TINY,
     },
     { ...testHarness },
   );
@@ -118,7 +118,7 @@ describe("Connection.connect, when passed connection options", () => {
     }
     const connection = Connection.connect(
       {
-        runtime: Runtime.SEDONA,
+        runtime: Runtime.TINY,
       },
       testHarness,
     );
@@ -135,7 +135,7 @@ describe("Connection.connect, when passed connection options", () => {
     try {
       const connection = Connection.connect(
         {
-          runtime: Runtime.SEDONA,
+          runtime: Runtime.TINY,
         },
         testHarness,
       );

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -3,23 +3,23 @@ export enum Region {
 }
 
 export enum Runtime {
-  SEDONA = "tiny",
-  SAN_FRANCISCO = "small",
-  NEW_YORK = "medium",
-  CAIRO = "large",
-  DELHI = "x-large",
-  TOKYO = "2x-large",
-  ATLANTIS = "4x-large",
+  TINY = "tiny",
+  SMALL = "small",
+  MEDIUM = "medium",
+  LARGE = "large",
+  X_LARGE = "x-large",
+  XX_LARGE = "2x-large",
+  XXXX_LARGE = "4x-large",
 
-  NEW_YORK_HIMEM = "medium-himem",
-  CAIRO_HIMEM = "large-himem",
-  DELHI_HIMEM = "x-large-himem",
-  TOKYO_HIMEM = "2x-large-himem",
-  ATLANTIS_HIMEM = "4x-large-himem",
+  MEDIUM_HIMEM = "medium-himem",
+  LARGE_HIMEM = "large-himem",
+  X_LARGE_HIMEM = "x-large-himem",
+  XX_LARGE_HIMEM = "2x-large-himem",
+  XXXX_LARGE_HIMEM = "4x-large-himem",
 
-  SEDONA_GPU = "tiny-a10-gpu",
-  SAN_FRANCISCO_GPU = "small-a10-gpu",
-  NEW_YORK_GPU = "medium-a10-gpu",
+  TINY_A10_GPU = "tiny-a10-gpu",
+  SMALL_A10_GPU = "small-a10-gpu",
+  MEDIUM_A10_GPU = "medium-a10-gpu",
 }
 
 export enum ResultsFormat {


### PR DESCRIPTION
and since it's technically a breaking change, added a changelog

extras:
- synced docs with what's on our docs site
- patch upgrade to `cross-spawn` library to fix vulnerability