### PR TITLE
chore: update package-lock.json with correct version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wherobots-sql-driver",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wherobots-sql-driver",
-      "version": "0.3.1",
+      "version": "0.3.2",
       "license": "Apache-2.0",
       "dependencies": {
         "apache-arrow": "^17.0.0",


### PR DESCRIPTION
my fault, forgot to run `npm install` after upgrading the version in package.json