### PR TITLE
chore: add PR template and size labeler workflow

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @wherobots/wbc-crew
+* @wherobots/wbc-frontend-crew

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,32 @@
+## Summary
+<!-- Brief description of what this PR does -->
+
+## Related Issues
+<!-- Link any related issues: Fixes #123, Relates to #456 -->
+
+---
+
+## Requester Checklist
+*Complete these before marking Ready for Review*
+
+- [ ] I have self-reviewed my own code
+- [ ] I have added/updated tests that prove my fix/feature works
+- [ ] I have included visual proof (screenshot, video, or test output) if applicable
+- [ ] All CI checks are passing
+- [ ] PR size is S/M, OR I have justified the size and added a walkthrough
+- [ ] I have updated documentation if needed
+
+### Visual Proof
+<!-- Add screenshots, videos, or test output here -->
+
+### Size Justification (if L/XL)
+<!-- If this PR is large, explain why it can't be split -->
+
+---
+
+## Reviewer Checklist
+*If these are not met, close the tab — this PR is not ready for review*
+
+- [ ] Requester checklist above is complete
+- [ ] All CI checks are passing
+- [ ] Tests adequately cover the changes

--- a/.github/workflows/pr-size-labeler.yaml
+++ b/.github/workflows/pr-size-labeler.yaml
@@ -1,0 +1,10 @@
+name: PR Size Labeler
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  label-size:
+    uses: wherobots/ci-tools/.github/workflows/pr-size-labeler.yaml@main
+    secrets: inherit


### PR DESCRIPTION
## Summary
Adds standardized PR template and automatic PR size labeling workflow.

- Adds `.github/PULL_REQUEST_TEMPLATE.md` with requester and reviewer checklists
- Adds `.github/workflows/pr-size-labeler.yaml` that uses the shared workflow from ci-tools