### PR TITLE
feat: add AWS US East 2 (Ohio) and AP South 1 (Mumbai) region support

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,8 +139,10 @@ The `Connection.connect()` function can take the following additional options:
 - `region`: You must also specify in which region your SQL session should execute
   into. Wherobots Cloud supports the following compute regions:
   - `aws-us-east-1`: AWS US East 1 (N. Virginia)
+  - `aws-us-east-2`: AWS US East 2 (Ohio)
   - `aws-us-west-2`: AWS US West 2 (Oregon)
   - `aws-eu-west-1`: AWS EU West 1 (Ireland)
+  - `aws-ap-south-1`: AWS AP South 1 (Mumbai)
 
 > [!IMPORTANT]
 > The `aws-us-west-2` region is available to all Wherobots Cloud users

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wherobots-sql-driver",
-  "version": "0.8.1",
+  "version": "0.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wherobots-sql-driver",
-      "version": "0.8.1",
+      "version": "0.9.0",
       "license": "Apache-2.0",
       "dependencies": {
         "apache-arrow": "^17.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wherobots-sql-driver",
-  "version": "0.8.1",
+  "version": "0.9.0",
   "description": "TypeScript SDK for Wherobots DB",
   "license": "Apache-2.0",
   "main": "dist/src/index.js",

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,10 +1,14 @@
 export enum Region {
   // Americas
   AWS_US_EAST_1 = "aws-us-east-1",
+  AWS_US_EAST_2 = "aws-us-east-2",
   AWS_US_WEST_2 = "aws-us-west-2",
 
   // EMEA
   AWS_EU_WEST_1 = "aws-eu-west-1",
+
+  // APAC
+  AWS_AP_SOUTH_1 = "aws-ap-south-1",
 }
 
 export enum Runtime {


### PR DESCRIPTION
## Summary

Add `AWS_US_EAST_2` (`aws-us-east-2`, Ohio) and `AWS_AP_SOUTH_1` (`aws-ap-south-1`, Mumbai) to the Region enum, bringing the TypeScript SDK to parity with the Python and JDBC SDKs. Bumps version to 0.9.0.

## Related Issues

N/A

---

## Requester Checklist

- [x] I have self-reviewed my own code
- [ ] I have added/updated tests that prove my fix/feature works
- [x] I have included visual proof (screenshot, video, or test output) if applicable
- [ ] All CI checks are passing
- [x] PR size is S/M, OR I have justified the size and added a walkthrough
- [x] I have updated documentation if needed

### Visual Proof

Enum-only change — no runtime behavior to screenshot. Region is passed as a query parameter to the API; no client-side routing involved.

---

## Reviewer Checklist

- [ ] Requester checklist above is complete
- [ ] All CI checks are passing
- [ ] Tests adequately cover the changes