### PR TITLE
feat: accept str|enum for region/runtime, make both optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,13 @@ Running this example returns the results of the query as JSON:
 
 ### Runtime and region selection
 
-Select your desired Wherobots runtime using the runtime parameter and specifying a runtime enum value.
+Both `runtime` and `region` are optional and accept either a `Runtime`/`Region`
+enum value (handy for autocomplete) or a plain string. Strings are passed to the
+API as-is, so new or BYOC regions (e.g. `region: "byoc-acme-us-east-1"`) work
+without an SDK upgrade. **When omitted, your organization's configured default
+runtime and region are used** — only set them to override that default with a
+specific runtime/region.
+
 See the [Wherobots product documentation](https://docs.wherobots.com) for guidance on runtime sizing and selection.
 
 ### Additional parameters to `connect()`
@@ -136,8 +142,10 @@ The `Connection.connect()` function can take the following additional options:
   convenient for human inspection while still being usable by
   geospatial data manipulation libraries.
 
-- `region`: You must also specify in which region your SQL session should execute
-  into. Wherobots Cloud supports the following compute regions:
+- `region`: the region your SQL session should execute in. Optional — when
+  omitted, your organization's configured default region is used. Accepts a
+  `Region` enum value or any string (BYOC regions included). Wherobots Cloud's
+  built-in compute regions are:
   - `aws-us-east-1`: AWS US East 1 (N. Virginia)
   - `aws-us-east-2`: AWS US East 2 (Ohio)
   - `aws-us-west-2`: AWS US West 2 (Oregon)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wherobots-sql-driver",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "description": "TypeScript SDK for Wherobots DB",
   "license": "Apache-2.0",
   "main": "dist/src/index.js",

--- a/src/connection.test.ts
+++ b/src/connection.test.ts
@@ -172,13 +172,55 @@ describe("Connection.connect, when passed connection options", () => {
     const connection = Connection.connect(
       {
         apiKey: testApiKey,
-        runtime: "invalid" as unknown as Runtime,
+        // A non-string runtime is still invalid (region/runtime now accept
+        // any string, but not arbitrary types).
+        runtime: 123 as unknown as Runtime,
       },
       testHarness,
     );
     vi.runAllTimersAsync();
     await expect(connection).rejects.toBeInstanceOf(Error);
     expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  test("passes raw region/runtime strings through (e.g. BYOC)", async () => {
+    simulateImmediatelyReadySession(fetchMock);
+    simulateImmediatelyOpenSocket(MockWebSocket);
+    const connection = Connection.connect(
+      {
+        apiKey: testApiKey,
+        runtime: "x-large",
+        region: "byoc-acme-us-east-1",
+      },
+      { ...testHarness },
+    );
+    vi.runAllTimersAsync();
+    await connection;
+    const createCall = fetchMock.mock.calls.find(
+      (call) => call[1]?.method === "POST",
+    );
+    expect(createCall?.[0]).toContain("region=byoc-acme-us-east-1");
+    const body = JSON.parse(createCall?.[1]?.body as string);
+    expect(body.runtimeId).toBe("x-large");
+  });
+
+  test("omits region and runtime when not provided", async () => {
+    simulateImmediatelyReadySession(fetchMock);
+    simulateImmediatelyOpenSocket(MockWebSocket);
+    const connection = Connection.connect(
+      {
+        apiKey: testApiKey,
+      },
+      { ...testHarness },
+    );
+    vi.runAllTimersAsync();
+    await connection;
+    const createCall = fetchMock.mock.calls.find(
+      (call) => call[1]?.method === "POST",
+    );
+    expect(createCall?.[0]).not.toContain("region=");
+    const body = JSON.parse(createCall?.[1]?.body as string);
+    expect(body.runtimeId).toBeUndefined();
   });
 
   test("defaults to 'single' session type", async () => {

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -127,23 +127,28 @@ export class Connection {
   }
 
   private async establishSession() {
+    // Only send `region` when set; an omitted region lets the API apply the
+    // organization's configured default. `runtimeId` is likewise dropped from
+    // the body below when undefined (JSON.stringify omits undefined values).
+    const sessionParams = new URLSearchParams();
+    if (this.options.region) {
+      sessionParams.set("region", this.options.region);
+    }
+    sessionParams.set("force_new", String(this.options.forceNew));
     const createdSession = await asyncOperationWithRetry(
       (signal) =>
-        this.fetch(
-          `${API_URL}/sql/session?region=${encodeURIComponent(this.options.region)}&force_new=${this.options.forceNew}`,
-          {
-            method: "POST",
-            body: JSON.stringify({
-              runtimeId: this.options.runtime,
-              version: this.options.version,
-              sessionType: this.options.sessionType,
-              shutdownAfterInactiveSeconds:
-                this.options.shutdownAfterInactiveSeconds,
-            }),
-            ...this.fetchOptions,
-            signal: combineAbortSignals(signal, this.fetchOptions.signal),
-          },
-        ),
+        this.fetch(`${API_URL}/sql/session?${sessionParams.toString()}`, {
+          method: "POST",
+          body: JSON.stringify({
+            runtimeId: this.options.runtime,
+            version: this.options.version,
+            sessionType: this.options.sessionType,
+            shutdownAfterInactiveSeconds:
+              this.options.shutdownAfterInactiveSeconds,
+          }),
+          ...this.fetchOptions,
+          signal: combineAbortSignals(signal, this.fetchOptions.signal),
+        }),
       {
         retryOn: shouldRetryForResiliency,
         retryDelay: backoffRetry,

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -2,9 +2,7 @@ import z from "zod";
 import {
   DataCompression,
   GeometryRepresentation,
-  Region,
   ResultsFormat,
-  Runtime,
   SessionStatus,
   SessionType,
 } from "./constants";
@@ -19,19 +17,21 @@ const apiKeySchema = z.string().min(1).max(255);
 
 const ConnectionOptionsSchema = z.object({
   apiKey: apiKeySchema.optional(),
-  // Accept a `Runtime` enum value (for autocomplete) or a raw string; strings
-  // are passed to the API as-is. When omitted, the org's default runtime is used.
+  // Accepts any non-empty string; `Runtime` enum values are passed through as-is.
+  // When omitted, the org's default runtime is used.
   runtime: z
-    .union([z.nativeEnum(Runtime), z.string()])
+    .string()
+    .min(1)
     .describe(
       "Override the default runtime set for your organization. Only set this if you need a specific runtime instead of the one your administrator has configured. When omitted, your organization's default runtime is used.",
     )
     .optional(),
-  // Accept a `Region` enum value (for autocomplete) or a raw string (e.g. a
-  // BYOC region like "byoc-acme-us-east-1"); strings are passed to the API
-  // as-is. When omitted, the org's default region is used.
+  // Accepts any non-empty string; `Region` enum values and BYOC region
+  // identifiers (e.g. "byoc-acme-us-east-1") are passed through as-is.
+  // When omitted, the org's default region is used.
   region: z
-    .union([z.nativeEnum(Region), z.string()])
+    .string()
+    .min(1)
     .describe(
       "Override the default region set for your organization. Only set this if you intend to use a specific region instead of the one your administrator has configured. When omitted, your organization's default region is used.",
     )

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -19,8 +19,23 @@ const apiKeySchema = z.string().min(1).max(255);
 
 const ConnectionOptionsSchema = z.object({
   apiKey: apiKeySchema.optional(),
-  runtime: z.nativeEnum(Runtime),
-  region: z.nativeEnum(Region).optional(),
+  // Accept a `Runtime` enum value (for autocomplete) or a raw string; strings
+  // are passed to the API as-is. When omitted, the org's default runtime is used.
+  runtime: z
+    .union([z.nativeEnum(Runtime), z.string()])
+    .describe(
+      "Override the default runtime set for your organization. Only set this if you need a specific runtime instead of the one your administrator has configured. When omitted, your organization's default runtime is used.",
+    )
+    .optional(),
+  // Accept a `Region` enum value (for autocomplete) or a raw string (e.g. a
+  // BYOC region like "byoc-acme-us-east-1"); strings are passed to the API
+  // as-is. When omitted, the org's default region is used.
+  region: z
+    .union([z.nativeEnum(Region), z.string()])
+    .describe(
+      "Override the default region set for your organization. Only set this if you intend to use a specific region instead of the one your administrator has configured. When omitted, your organization's default region is used.",
+    )
+    .optional(),
   version: z.string().nullable().optional(),
   resultsFormat: z.literal(ResultsFormat.ARROW).optional(),
   dataCompression: z.literal(DataCompression.BROTLI).optional(),
@@ -37,7 +52,9 @@ export type ConnectionOptions = z.infer<typeof ConnectionOptionsSchema>;
 export const ConnectionOptionsSchemaNormalized = ConnectionOptionsSchema.extend(
   {
     apiKey: apiKeySchema,
-    region: ConnectionOptionsSchema.shape.region.default(Region.AWS_US_WEST_2),
+    // No region/runtime default: when the consumer omits them they stay
+    // undefined and are dropped from the request so the API applies the
+    // organization's configured defaults.
     resultsFormat: ConnectionOptionsSchema.shape.resultsFormat.default(
       ResultsFormat.ARROW,
     ),


### PR DESCRIPTION
## Summary

`runtime` and `region` connection options now accept a `Runtime`/`Region` enum value **or** a raw string:

- Schema widened to `z.union([z.nativeEnum(X), z.string()]).optional()` for both, with `.describe()` docs (override-vs-org-default semantics).
- Removed the hardcoded `Region.AWS_US_WEST_2` default from the normalized schema; `runtime` is no longer required.
- `establishSession` only appends `region=` to the URL when set, and `runtimeId` is dropped from the body when undefined — so an omitted value lets the **API apply the organization's configured default**. Strings pass through untouched (BYOC regions like `byoc-acme-us-east-1` work without an SDK release).
- Updated the "rejects invalid arguments" test to use a non-string (arbitrary strings are now valid); added tests for string passthrough and omission. README updated.

**Why:** part of the BYOC region rollout. Depends on wherobots/studio-backend#2208 (region/runtime optional on `POST /sql/session`).

> [!NOTE]
> Release of this package is handled manually by Simon — no version bump / CHANGELOG entry / publish is included here; please add those at release time.

## Test plan / notes

- `npm run build:check` — passes (also runs in the pre-commit hook).
- `npx vitest run` — the new connect tests pass (`passes raw region/runtime strings through`, `omits region and runtime when not provided`). The 6 failing `Connection#execute` tests are **pre-existing flakiness on `dev`** (fake-timer 5s timeouts), unrelated to this change — verified by stashing this change and re-running on the base branch (same 6 failures).
- eslint + prettier clean on changed files.