### PR TITLE
chore: bump version to 0.12.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wherobots-sql-driver",
-  "version": "0.11.1",
+  "version": "0.12.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wherobots-sql-driver",
-      "version": "0.11.1",
+      "version": "0.12.0",
       "license": "Apache-2.0",
       "dependencies": {
         "apache-arrow": "^17.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wherobots-sql-driver",
-  "version": "0.11.1",
+  "version": "0.12.0",
   "description": "TypeScript SDK for Wherobots DB",
   "license": "Apache-2.0",
   "main": "./dist/node/index.js",


### PR DESCRIPTION
## Summary

Bumps the package version `0.11.1` → `0.12.0` to cut a release. **Version bump only — no source changes.**

`0.12.0` ships the **X-Wherobots-Client attribution hop fix** (#48, merged to `dev` 2026-08-07 and unpublished since). The SDK had been emitting the legacy `X-Wherobots-Client: wherobots-sql-driver/<version>` format, which the backend parser records as `unknown` — so every request from this SDK has been logged as unattributed rather than as a TypeScript SDK request. `0.12.0` emits a real `client=typescript-sdk;ver=<v>;plat=<p>` hop.

npm `latest` is still `0.11.1` (published 2026-07-10).

### Files changed

| File | Change |
| --- | --- |
| `package.json` | `version`: `0.11.1` → `0.12.0` |
| `package-lock.json` | both version fields (top-level and `packages.""`) → `0.12.0` |

The lockfile carries the version in **two** places; both are updated so the CI `Check package-lock.json is up to date` step stays green. Verified locally by running that exact step (`npm install --package-lock-only --ignore-scripts`) — it produces no further changes.

### Why minor, not patch

Although #48 is prefixed `fix:`, it is additive to the public API — it introduced `src/clientHeader.ts` and a new optional `clientChain` connection option (`src/schemas.ts`) — so a minor bump is the correct level. It is not breaking for consumers: the changed header is outbound-only and advisory, and no SDK API was removed or renamed.

## Related Issues

Releases #48.

---

## Requester Checklist

- [x] I have self-reviewed my own code
- [ ] I have added/updated tests that prove my fix/feature works — N/A, version-only change; the behaviour being released is already covered by `src/clientHeader.test.ts` (15 tests) on `dev`
- [x] I have included visual proof (screenshot, video, or test output) if applicable
- [x] All CI checks are passing
- [x] PR size is S/M, OR I have justified the size and added a walkthrough
- [x] I have updated documentation if needed

### Visual Proof

CI on this branch: **Passed 1, Failed 0.**

Full CI pipeline also reproduced locally before pushing:

```
LINT EXIT: 0
FORMAT EXIT: 0
BUILDCHECK EXIT: 0

 ✓ src/bundle.smoke.test.ts (8 tests)
 ✓ src/clientHeader.test.ts (15 tests)
 ✓ src/platform/decompress.test.ts (5 tests)
 ✓ src/connection.test.ts (38 tests)
 ✓ src/acceptance.node.test.ts (4 tests)

 Test Files  5 passed (5)
      Tests  70 passed (70)
```

Diff is exactly 3 lines across 2 files:

```
 package-lock.json | 4 ++--
 package.json      | 2 +-
 2 files changed, 3 insertions(+), 3 deletions(-)
```

## Notes for the reviewer

- **`npm publish` is deliberately not automated here** and is not part of this PR — it remains a manual step after merge. This repo has no release automation and no release tags.
- `CHANGELOG.md` is intentionally untouched: it is only sporadically maintained (entries exist for `0.11.0` and `0.3.0` only; `0.4`–`0.10` and `0.11.1` are all absent), and no previous version-bump commit has updated it. Happy to add a `0.12.0` entry if you'd prefer to start that habit with this release.